### PR TITLE
feat: add http plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "extism-pdk",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"store_credit",
   "loop_forever",
   "count_vowels_kvstore",
+	"http"
 ]
 resolver = "2"
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "http"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+extism-pdk = {workspace = true}
+serde = {workspace = true}
+anyhow = {workspace = true}
+
+[lib]
+crate_type = ["cdylib"]

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,0 +1,22 @@
+use extism_pdk::*;
+
+#[plugin_fn]
+pub unsafe fn http_get(Json(input): Json<HttpRequest>) -> FnResult<Vec<u8>> {
+    let res = http::request::<()>(&input, None)?;
+    let res = res.body();
+    Ok(res)
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct HttpRequestWithBody {
+    #[serde(flatten)]
+    req: HttpRequest,
+    data: String,
+}
+
+#[plugin_fn]
+pub unsafe fn http_post(Json(input): Json<HttpRequestWithBody>) -> FnResult<Vec<u8>> {
+    let res = http::request::<&str>(&input.req, Some(&input.data))?;
+    let res = res.body();
+    Ok(res)
+}


### PR DESCRIPTION
Adds an `http` plugin with an `http_request` function that can be used to test http requests with or without an request body.